### PR TITLE
Cubic Bezier feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,33 +68,50 @@ const customH: SvgChar = {
 
 Behavior and design of a single character (not embedded into a phrase) can be modified by passing following props:
 
-- char [string] - character to be rendered. Each font has its own limitations for allowed characters.
-- delay? [number] - number of seconds by which the start of animation will be delayed. Default value: 0.
-- duration? [number] - duration of the animation in seconds. Default value: 1.
-- color? [string] - definition of the color of the character. Should be in format accepted by CSS standards. Default value: #000000.
-- size? [number] - size of the character in "px" unit. Default value: 100.
-- font? [string] - name of the font. Each font has different design of characters and may have different characters available. Default value: "basic-bold".
+- char `<string>` - character to be rendered. Each font has its own limitations for allowed characters.
+- delay? `<number>` - number of seconds by which the start of animation will be delayed. Default value: 0.
+- duration? `<number>` - duration of the animation in seconds. Default value: 1.
+- color? `<string>` - definition of the color of the character. Should be in format accepted by CSS standards. Default value: #000000.
+- size? `<number>` - size of the character in "px" unit. Default value: 100.
+- font? `<string>` - name of the font. Each font has different design of characters and may have different characters available. Default value: "basic-bold".
+- cubicBezier? `<[number, number, number, number]>` - definition of a Cubic Bezier curve used for `animation-timing-function` property. If not provided then `linear` function is used.
 
 Example:
 
 ```js
-<Char char='A' delay={1.5} duration={0.8} color='#6600cc' size={300} font='basic-thin' />
+<Char
+	char='A'
+	delay={1.5}
+	duration={0.8}
+	color='#6600cc'
+	size={300}
+	font='basic-thin'
+	cubicBezier={[0.68, 0.04, 0.45, 0.98]}
+/>
 ```
 
 ## Phrase:
 
 Behavior and design of characters grouped in the phrase can be modified by passing following props:
 
-- margin? [number] - number of pixel "px" units between characters in a phrase. Default value: 0.
-- color? [string] - definition of the color of the characters in a phrase. Should be in format accepted by CSS standards. Default value: #000000. Value is overwritten by the color defined in the character element.
-- size? [string] - size of the characters in "px" unit. Default value: 100. Value overwrites size value of all children elements.
-- duration? [number] - duration of the animation in seconds. Default value: 1. Value is overwritten by the value defined in the character element.
-- font? [string] - name of the font. Each font has different design of characters and may have different characters available. Default value: "basic-bold". Value overwrites size value of all children elements.
+- margin? `<number>` - number of pixel "px" units between characters in a phrase. Default value: 0.
+- color? `<string>` - definition of the color of the characters in a phrase. Should be in format accepted by CSS standards. Default value: #000000. Value is overwritten by the color defined in the character element.
+- size? `<string>` - size of the characters in "px" unit. Default value: 100. Value overwrites size value of all children elements.
+- duration? `<number>` - duration of the animation in seconds. Default value: 1. Value is overwritten by the value defined in the character element.
+- font? `<string>` - name of the font. Each font has different design of characters and may have different characters available. Default value: "basic-bold". Value overwrites size value of all children elements.
+- cubicBezier? `<[number, number, number, number]>` - definition of a Cubic Bezier curve used for `animation-timing-function` property. If not provided then `linear` function is used. Value is overwritten by the value defined in the character element.
 
 Example:
 
 ```js
-<Phrase color='#6600cc' margin={50} size={200} duration={1.1} font='basic-thin'>
+<Phrase
+	color='#6600cc'
+	margin={50}
+	size={200}
+	duration={1.1}
+	font='basic-thin'
+	cubicBezier={[0.68, 0.04, 0.45, 0.98]}
+>
 	<Char char='A' />
 	<Char char='B' />
 	...

--- a/src/components/Character.tsx
+++ b/src/components/Character.tsx
@@ -25,6 +25,7 @@ interface PathProps {
 	duration: number;
 	length: number;
 	key: number;
+	cubicBezier?: [number, number, number, number];
 }
 
 interface ExtendedElement extends Element {
@@ -43,6 +44,7 @@ export interface CharacterProps {
 	color?: string;
 	size?: number;
 	font?: FontOptions;
+	cubicBezier?: [number, number, number, number];
 }
 
 const Character: React.FC<CharacterProps> = ({
@@ -52,6 +54,7 @@ const Character: React.FC<CharacterProps> = ({
 	color = '#000000',
 	size = 100,
 	font = 'font1',
+	cubicBezier,
 }) => {
 	const [character, setCharacter] = useState<ExtendedSvgChar>({
 		...defaultCharacter,
@@ -136,6 +139,7 @@ const Character: React.FC<CharacterProps> = ({
 						d={shape}
 						length={length}
 						key={index}
+						cubicBezier={cubicBezier}
 					/>
 				),
 			)}
@@ -169,5 +173,6 @@ const Path = styled.path<PathProps>`
 	animation-fill-mode: forwards; //Animated object stays instead of disappearing
 	animation-duration: ${(props: PathProps) => props.duration}s; //Animation length (without delay)
 	animation-delay: ${props => props.delay}s;
-	animation-timing-function: cubic-bezier(1, 0.04, 0.02, 1);
+	animation-timing-function: ${(props: PathProps) =>
+		props.cubicBezier ? `cubic-bezier(${props.cubicBezier})` : 'linear'};
 `;

--- a/src/components/Character.tsx
+++ b/src/components/Character.tsx
@@ -169,4 +169,5 @@ const Path = styled.path<PathProps>`
 	animation-fill-mode: forwards; //Animated object stays instead of disappearing
 	animation-duration: ${(props: PathProps) => props.duration}s; //Animation length (without delay)
 	animation-delay: ${props => props.delay}s;
+	animation-timing-function: cubic-bezier(1, 0.04, 0.02, 1);
 `;

--- a/src/components/Character.tsx
+++ b/src/components/Character.tsx
@@ -44,7 +44,7 @@ export interface CharacterProps {
 	color?: string;
 	size?: number;
 	font?: FontOptions;
-	cubicBezier?: [number, number, number, number];
+	cubicBezier?: PathProps['cubicBezier'];
 }
 
 const Character: React.FC<CharacterProps> = ({

--- a/src/components/Phrase.tsx
+++ b/src/components/Phrase.tsx
@@ -25,19 +25,21 @@ interface OffsetWrapperProps {
 interface PhraseProps {
 	children: ChildType | ChildType[];
 	margin?: number;
+	duration?: number;
 	color?: string;
 	size?: number;
-	duration?: number;
 	font?: FontOptions;
+	cubicBezier?: CharacterProps['cubicBezier'];
 }
 
 const Phrase: React.FC<PhraseProps> = ({
 	children,
 	margin = 0,
+	duration = 1,
 	color,
 	size = 100,
-	duration = 1,
 	font = 'font1',
+	cubicBezier,
 }) => {
 	const [characters, setCharacters] = useState<OffsetWrappedChildType[]>([]);
 
@@ -48,10 +50,11 @@ const Phrase: React.FC<PhraseProps> = ({
 					? { chosenChar: child.props.char }
 					: getCharacterAndFontData(child.props.char, child.props.font ?? font);
 				const newChild: WrappedChildType = React.cloneElement(child as React.ReactElement<any>, {
+					duration: child.props.duration ?? duration,
 					color: child.props.color ?? color,
 					size,
-					duration: child.props.duration ?? duration,
 					font,
+					cubicBezier: child.props.cubicBezier ?? cubicBezier,
 					margin,
 					offsets: chosenChar.offsets,
 					svgViewBox: chosenChar.svgViewBox,
@@ -59,7 +62,7 @@ const Phrase: React.FC<PhraseProps> = ({
 
 				return newChild;
 			}),
-		[color, duration, font, margin, size],
+		[color, cubicBezier, duration, font, margin, size],
 	);
 
 	const addOffset = (children: WrappedChildType[]): OffsetWrappedChildType[] => {


### PR DESCRIPTION
<!--- Remeber to add a meaningful title -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Adding new prop `cubicBezier` for the `Char` and `Phrase` components for smoothing animation. New prop accepts an array of four numbers that defines Cubic Bezier curve used for the `animation-timing-function`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changes tested manually.

## Screenshots (if appropriate):
