### PR TITLE
Phrase delay feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Behavior and design of characters grouped in the phrase can be modified by passi
 - color? `<string>` - definition of the color of the characters in a phrase. Should be in format accepted by CSS standards. Default value: #000000. Value is overwritten by the color defined in the character element.
 - size? `<string>` - size of the characters in "px" unit. Default value: 100. Value overwrites size value of all children elements.
 - duration? `<number>` - duration of the animation in seconds. Default value: 1. Value is overwritten by the value defined in the character element.
+- delay? `<number>` - number of seconds by which the start of the phrase animation will be delayed. When specified, this value is added to the delay of each `Char` component within the `Phrase`. Default value: 0.
 - font? `<string>` - name of the font. Each font has different design of characters and may have different characters available. Default value: "basic-bold". Value overwrites size value of all children elements.
 - cubicBezier? `<[number, number, number, number]>` - definition of a Cubic Bezier curve used for `animation-timing-function` property. If not provided then `linear` function is used. Value is overwritten by the value defined in the character element.
 

--- a/src/components/Phrase.tsx
+++ b/src/components/Phrase.tsx
@@ -25,6 +25,7 @@ interface OffsetWrapperProps {
 interface PhraseProps {
 	children: ChildType | ChildType[];
 	margin?: number;
+	delay?: number;
 	duration?: number;
 	color?: string;
 	size?: number;
@@ -35,6 +36,7 @@ interface PhraseProps {
 const Phrase: React.FC<PhraseProps> = ({
 	children,
 	margin = 0,
+	delay = 0,
 	duration = 1,
 	color,
 	size = 100,
@@ -50,6 +52,7 @@ const Phrase: React.FC<PhraseProps> = ({
 					? { chosenChar: child.props.char }
 					: getCharacterAndFontData(child.props.char, child.props.font ?? font);
 				const newChild: WrappedChildType = React.cloneElement(child as React.ReactElement<any>, {
+					delay: (child.props.delay ?? 0) + delay,
 					duration: child.props.duration ?? duration,
 					color: child.props.color ?? color,
 					size,
@@ -62,7 +65,7 @@ const Phrase: React.FC<PhraseProps> = ({
 
 				return newChild;
 			}),
-		[color, cubicBezier, duration, font, margin, size],
+		[color, cubicBezier, delay, duration, font, margin, size],
 	);
 
 	const addOffset = (children: WrappedChildType[]): OffsetWrappedChildType[] => {


### PR DESCRIPTION
<!--- Remeber to add a meaningful title -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR implements delay for the `Phrase` component. When specified, the value is added to the delay value of each `Char` child, thus delaying the animation of the whole `Phrase`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changes tested manually.

## Screenshots (if appropriate):
