### PR TITLE
Reverse animation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Behavior and design of a single character (not embedded into a phrase) can be mo
 - size? `<number>` - size of the character in "px" unit. Default value: 100.
 - font? `<string>` - name of the font. Each font has different design of characters and may have different characters available. Default value: "basic-bold".
 - cubicBezier? `<[number, number, number, number]>` - definition of a Cubic Bezier curve used for `animation-timing-function` property. If not provided then `linear` function is used.
+- isReversed? `<boolean>` - flag that determines whether animation should be reversed. If `true`, animation is played backwards thus the character is disappearing. Default value: `false`.
 
 Example:
 
@@ -101,6 +102,7 @@ Behavior and design of characters grouped in the phrase can be modified by passi
 - delay? `<number>` - number of seconds by which the start of the phrase animation will be delayed. When specified, this value is added to the delay of each `Char` component within the `Phrase`. Default value: 0.
 - font? `<string>` - name of the font. Each font has different design of characters and may have different characters available. Default value: "basic-bold". Value overwrites size value of all children elements.
 - cubicBezier? `<[number, number, number, number]>` - definition of a Cubic Bezier curve used for `animation-timing-function` property. If not provided then `linear` function is used. Value is overwritten by the value defined in the character element.
+- isReversed? `<boolean>` - flag that determines whether animation should be reversed. If `true`, animation is played backwards thus the character is disappearing. Default value: `false`. Value overrides children property.
 
 Example:
 

--- a/src/components/Character.tsx
+++ b/src/components/Character.tsx
@@ -26,6 +26,7 @@ interface PathProps {
 	length: number;
 	key: number;
 	cubicBezier?: [number, number, number, number];
+	isReversed: boolean;
 }
 
 interface ExtendedElement extends Element {
@@ -45,6 +46,7 @@ export interface CharacterProps {
 	size?: number;
 	font?: FontOptions;
 	cubicBezier?: PathProps['cubicBezier'];
+	isReversed?: boolean;
 }
 
 const Character: React.FC<CharacterProps> = ({
@@ -55,6 +57,7 @@ const Character: React.FC<CharacterProps> = ({
 	size = 100,
 	font = 'font1',
 	cubicBezier,
+	isReversed = false,
 }) => {
 	const [character, setCharacter] = useState<ExtendedSvgChar>({
 		...defaultCharacter,
@@ -140,6 +143,7 @@ const Character: React.FC<CharacterProps> = ({
 						length={length}
 						key={index}
 						cubicBezier={cubicBezier}
+						isReversed={isReversed}
 					/>
 				),
 			)}
@@ -156,20 +160,20 @@ const Svg = styled.svg<SvgProps>`
 	stroke-linecap: ${(props: SvgProps) => props.linecap};
 `;
 
-const animate = (length: any) => keyframes`
+const animate = (length: any, isReversed: boolean) => keyframes`
 from {
-  stroke-dashoffset: ${length};
+	stroke-dashoffset: ${isReversed ? 0 : length};
 }
 to {
-  stroke-dashoffset: 0;
+	stroke-dashoffset: ${isReversed ? length : 0};
 }
 `;
 
 const Path = styled.path<PathProps>`
 	fill: transparent;
 	stroke-dasharray: ${(props: PathProps) => props.length};
-	stroke-dashoffset: ${(props: PathProps) => props.length};
-	animation: ${(props: PathProps) => animate(props.length)} 2s linear;
+	stroke-dashoffset: ${(props: PathProps) => (props.isReversed ? 0 : props.length)};
+	animation: ${(props: PathProps) => animate(props.length, props.isReversed)} 2s linear;
 	animation-fill-mode: forwards; //Animated object stays instead of disappearing
 	animation-duration: ${(props: PathProps) => props.duration}s; //Animation length (without delay)
 	animation-delay: ${props => props.delay}s;

--- a/src/components/Character.tsx
+++ b/src/components/Character.tsx
@@ -38,6 +38,20 @@ interface ExtendedSvgChar extends SvgChar {
 	elements: ExtendedElement[];
 }
 
+const reverseElements = (char: ExtendedSvgChar) => {
+	const sortedElements = char.elements.sort(
+		(current, next) => current.elementDelay - next.elementDelay,
+	);
+
+	let rememberedValue;
+	for (let i = 0; i < Math.floor(sortedElements.length / 2); i += 1) {
+		rememberedValue = sortedElements[i].elementDelay;
+		sortedElements[i].elementDelay = sortedElements[sortedElements.length - 1 - i].elementDelay;
+		sortedElements[sortedElements.length - 1 - i].elementDelay = rememberedValue;
+	}
+	return char;
+};
+
 export interface CharacterProps {
 	char: CharOptions | SvgChar;
 	delay?: number;
@@ -71,12 +85,12 @@ const Character: React.FC<CharacterProps> = ({
 			? { chosenChar: char, ...getFontData(font) }
 			: getCharacterAndFontData(char, font);
 		const newChar = calculateAnimation(chosenChar, duration);
-		setCharacter(newChar);
+		setCharacter(isReversed ? reverseElements(newChar) : newChar);
 		setFontWidth(fontWidth);
 		setLinecap(linecap);
-	}, [char, duration, font]);
+	}, [char, duration, font, isReversed]);
 
-	const calculateAnimation = (char: SvgChar, animationTime: number) => {
+	const calculateAnimation = (char: SvgChar, animationTime: number): ExtendedSvgChar => {
 		// Find the longest element in character
 		let longestElement = 0;
 		char.elements.forEach(element => {

--- a/src/components/Phrase.tsx
+++ b/src/components/Phrase.tsx
@@ -31,6 +31,7 @@ interface PhraseProps {
 	size?: number;
 	font?: FontOptions;
 	cubicBezier?: CharacterProps['cubicBezier'];
+	isReversed?: boolean;
 }
 
 const Phrase: React.FC<PhraseProps> = ({
@@ -42,6 +43,7 @@ const Phrase: React.FC<PhraseProps> = ({
 	size = 100,
 	font = 'font1',
 	cubicBezier,
+	isReversed = false,
 }) => {
 	const [characters, setCharacters] = useState<OffsetWrappedChildType[]>([]);
 
@@ -58,6 +60,7 @@ const Phrase: React.FC<PhraseProps> = ({
 					size,
 					font,
 					cubicBezier: child.props.cubicBezier ?? cubicBezier,
+					isReversed,
 					margin,
 					offsets: chosenChar.offsets,
 					svgViewBox: chosenChar.svgViewBox,
@@ -65,7 +68,7 @@ const Phrase: React.FC<PhraseProps> = ({
 
 				return newChild;
 			}),
-		[color, cubicBezier, delay, duration, font, margin, size],
+		[color, cubicBezier, delay, duration, font, isReversed, margin, size],
 	);
 
 	const addOffset = (children: WrappedChildType[]): OffsetWrappedChildType[] => {


### PR DESCRIPTION
<!--- Remeber to add a meaningful title -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR implements optional reversing of animation. Thanks to the new `isReversed` flag animation can be played backwards thus the `Char`/`Phrase` is disappearing.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changes tested manually.

## Screenshots (if appropriate):
