### PR TITLE
Fixing reversed animation

### DIFF
--- a/src/utils/characterUtils.ts
+++ b/src/utils/characterUtils.ts
@@ -2,19 +2,18 @@ import { ExtendedSvgChar } from '@/types/character';
 import { SvgChar } from '@/types/font';
 
 export const reverseElements = (char: ExtendedSvgChar) => {
-	const sortedElements = char.elements.sort(
-		(current, next) => current.elementDelay - next.elementDelay,
-	);
+	const newElements = char.elements.map(element => {
+		const newDelay =
+			element.elementDuration + element.elementDelay === 1
+				? 0
+				: 1 - element.elementDelay - element.elementDuration;
+		return {
+			...element,
+			elementDelay: newDelay,
+		};
+	});
 
-	let rememberedValue;
-	for (let i = 0; i < Math.floor(sortedElements.length / 2); i += 1) {
-		rememberedValue = sortedElements[i].elementDelay;
-		sortedElements[i].elementDelay =
-			sortedElements[sortedElements.length - 1 - i].elementDelay;
-		sortedElements[sortedElements.length - 1 - i].elementDelay =
-			rememberedValue;
-	}
-	return char;
+	return { ...char, elements: newElements };
 };
 
 export const calculateAnimation = (
@@ -52,7 +51,7 @@ export const calculateAnimation = (
 
 	// Calculate adjustment if animation longer than animationTime
 	let alpha = 1;
-	if (lastEnd > animationTime) {
+	if (lastEnd !== animationTime) {
 		// Calculate time of element's animation which is too long
 		const lasts = lastEnd - longestAnimation.elementDelay * animationTime;
 


### PR DESCRIPTION
<!--- Remember to add a meaningful title -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This bug fixes the reversed animation feature. Without this fix the overall time of the reversed animation doesn't match the time of normal animation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
