### PR TITLE
Fixing unrecognized prop issue

### DIFF
--- a/src/components/Character.tsx
+++ b/src/components/Character.tsx
@@ -49,10 +49,10 @@ const Character: React.FC<CharacterProps> = ({
 
 	return (
 		<Svg
-			color={color}
-			size={size}
-			fontWidth={fontWidth}
-			linecap={linecap}
+			$color={color}
+			$size={size}
+			$fontWidth={fontWidth}
+			$linecap={linecap}
 			viewBox={`0 0 ${character.svgViewBox.width} ${character.svgViewBox.height}`}
 		>
 			{character.elements.map(
@@ -61,13 +61,13 @@ const Character: React.FC<CharacterProps> = ({
 					index: number,
 				) => (
 					<Path
-						delay={delay + elementDelay * duration}
-						duration={elementDuration}
+						$delay={delay + elementDelay * duration}
+						$duration={elementDuration}
 						d={shape}
-						length={length}
+						$length={length}
 						key={index}
-						cubicBezier={cubicBezier}
-						isReversed={isReversed}
+						$cubicBezier={cubicBezier}
+						$isReversed={isReversed}
 					/>
 				),
 			)}
@@ -78,10 +78,10 @@ const Character: React.FC<CharacterProps> = ({
 export default Character;
 
 const Svg = styled.svg<SvgProps>`
-	stroke: ${(props: SvgProps) => props.color};
-	height: ${(props: SvgProps) => props.size}px;
-	stroke-width: ${(props: SvgProps) => props.fontWidth};
-	stroke-linecap: ${(props: SvgProps) => props.linecap};
+	stroke: ${(props: SvgProps) => props.$color};
+	height: ${(props: SvgProps) => props.$size}px;
+	stroke-width: ${(props: SvgProps) => props.$fontWidth};
+	stroke-linecap: ${(props: SvgProps) => props.$linecap};
 `;
 
 const animate = (length: number, isReversed: boolean) => keyframes`
@@ -95,17 +95,17 @@ to {
 
 const Path = styled.path<PathProps>`
 	fill: transparent;
-	stroke-dasharray: ${(props: PathProps) => props.length};
+	stroke-dasharray: ${(props: PathProps) => props.$length};
 	stroke-dashoffset: ${(props: PathProps) =>
-		props.isReversed ? 0 : props.length};
-	animation: ${(props: PathProps) => animate(props.length, props.isReversed)} 2s
-		linear;
+		props.$isReversed ? 0 : props.$length};
+	animation: ${(props: PathProps) => animate(props.$length, props.$isReversed)}
+		2s linear;
 	animation-fill-mode: forwards; //Animated object stays instead of disappearing
 	animation-duration: ${(props: PathProps) =>
-		props.duration}s; //Animation length (without delay)
-	animation-delay: ${props => props.delay}s;
+		props.$duration}s; //Animation length (without delay)
+	animation-delay: ${props => props.$delay}s;
 	animation-timing-function: ${(props: PathProps) =>
-		props.cubicBezier
-			? `cubic-bezier(${props.cubicBezier.toString()})`
+		props.$cubicBezier
+			? `cubic-bezier(${props.$cubicBezier.toString()})`
 			: 'linear'};
 `;

--- a/src/components/Phrase.tsx
+++ b/src/components/Phrase.tsx
@@ -45,9 +45,9 @@ const addOffset = (children: WrappedChildType[]): OffsetWrappedChildType[] => {
 
 		const childWithOffset = (
 			<OffsetWrapper
-				offsetLeft={rememberedSmallestSpaceLeft * (fcActualWidth / 2)}
-				offsetRight={smallestSpaceRight * (fcActualWidth / 2)}
-				globalMargin={fcMargin}
+				$offsetLeft={rememberedSmallestSpaceLeft * (fcActualWidth / 2)}
+				$offsetRight={smallestSpaceRight * (fcActualWidth / 2)}
+				$globalMargin={fcMargin}
 				key={i}
 			>
 				{children[i]}
@@ -135,9 +135,11 @@ const Content = styled.div`
 const OffsetWrapper = styled.div<OffsetWrapperProps>`
 	display: inline-flex;
 	${props =>
-		`margin-left: calc(${props.globalMargin / 2}px - ${props.offsetLeft}px);`}
+		`margin-left: calc(${props.$globalMargin / 2}px - ${props.$offsetLeft}px);`}
 	${props =>
-		`margin-right: calc(${props.globalMargin / 2}px - ${props.offsetRight}px);`}
+		`margin-right: calc(${props.$globalMargin / 2}px - ${
+			props.$offsetRight
+		}px);`}
 	&:first-child {
 		margin-left: 0;
 	}

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -7,19 +7,19 @@ import {
 } from './font';
 
 export interface SvgProps {
-	color: string;
-	size: number;
-	fontWidth: number;
-	linecap: LinecapOptions;
+	$color: string;
+	$size: number;
+	$fontWidth: number;
+	$linecap: LinecapOptions;
 }
 
 export interface PathProps {
-	delay: number;
-	duration: number;
-	length: number;
+	$delay: number;
+	$duration: number;
+	$length: number;
 	key: number;
-	cubicBezier?: [number, number, number, number];
-	isReversed: boolean;
+	$cubicBezier?: [number, number, number, number];
+	$isReversed: boolean;
 }
 
 export interface ExtendedElement extends Element {
@@ -38,6 +38,6 @@ export interface CharacterProps {
 	color?: string;
 	size?: number;
 	font?: FontOptions;
-	cubicBezier?: PathProps['cubicBezier'];
+	cubicBezier?: PathProps['$cubicBezier'];
 	isReversed?: boolean;
 }

--- a/src/types/phrase.ts
+++ b/src/types/phrase.ts
@@ -17,7 +17,7 @@ export type WrappedChildType = ReactElement<CharacterProps & WrapperProps>;
 export type OffsetWrappedChildType = ReactElement<OffsetWrapperProps>;
 
 export interface OffsetWrapperProps {
-	offsetRight: number;
-	offsetLeft: number;
-	globalMargin: number;
+	$offsetRight: number;
+	$offsetLeft: number;
+	$globalMargin: number;
 }


### PR DESCRIPTION
<!--- Remember to add a meaningful title -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR changes normal `styled component` props to transient props to solve the following error:

> React does not recognize the `xxx` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase someProp instead. If you accidentally passed it from a parent component, remove it from the DOM element.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
